### PR TITLE
Address feedback from CR

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -141,6 +141,7 @@ window.CMS.page_blocks = ->
         CMS.timepicker()
         CMS.codemirror()
         CMS.page_file_popovers()
+        document.dispatchEvent(new CustomEvent('cms_page_blocks'))
 
 
 window.CMS.page_file_popovers = ->

--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -148,8 +148,12 @@ protected
 
   def validate_format_of_unescaped_slug
     return unless slug.present?
-    #unescaped_slug = CGI::unescape(self.slug)
-    #errors.add(:slug, :invalid) unless unescaped_slug =~ /^\p{Alnum}[\.\p{Alnum}\p{Mark}_-]*$/i
+    # We are disabling this validation so we can define more than one level of hierarchy
+    # in a page slug, for example a page`baz` with path /foo/bar/baz, without
+    # needing a page to exist at foo and bar.
+
+    # unescaped_slug = CGI::unescape(self.slug)
+    # errors.add(:slug, :invalid) unless unescaped_slug =~ /^\p{Alnum}[\.\p{Alnum}\p{Mark}_-]*$/i
   end
 
   # Forcing re-saves for child pages so they can update full_paths
@@ -163,12 +167,14 @@ protected
 
   # Escape slug unless it's nonexistent (root)
   def escape_slug
+    # commented out as for our purposes we dont want to escape slugs
+    # see block comment above in validate_format_of_unescaped_slug
+
     # self.slug = CGI::escape(self.slug) unless self.slug.nil?
   end
 
   # Unescape the slug and full path back into their original forms unless they're nonexistent
   def unescape_slug_and_path
-    self.slug       = CGI::unescape(self.slug)      unless self.slug.nil?
     self.slug       = CGI::unescape(self.slug)      unless self.slug.nil?
     self.full_path  = CGI::unescape(self.full_path) unless self.full_path.nil?
   end


### PR DESCRIPTION
#### What changed
- Added comments for future reference about slug validation
- Created a window event in the `page_block` success callback. This provides a hook for our custom JS to use to load the cloudinary widget rather than re-defining / overriding this entire function in our custom JS. Usage can be seen [here](https://github.com/zozi/zozi-cms/pull/1/files#diff-9a4d6217c6f77c03511ed8e1a55cb879R67) in the sister PR
