### PR TITLE
Admin ui updates

### DIFF
--- a/app/helpers/comfy/cms_helper.rb
+++ b/app/helpers/comfy/cms_helper.rb
@@ -81,5 +81,10 @@ module Comfy
         paginate collection, :theme => 'comfy'
       end
     end
+
+    def friendly_date(date)
+      date.in_time_zone(Time.zone.name).strftime('%b %e, %l:%M%p')
+    end
+
   end
 end

--- a/app/views/comfy/admin/cms/pages/_index_branch.html.haml
+++ b/app/views/comfy/admin/cms/pages/_index_branch.html.haml
@@ -7,29 +7,41 @@
 - category_view = params[:category].present?
 
 %li{:id => dom_id(page)}
-  .item
+  .item{:class => page.published?? '' : 'draft'}
     .toggle{:class => branch_open ? 'open' : nil}
       - if !category_view && has_children && !page.root?
         = link_to toggle_branch_comfy_admin_cms_site_page_path(@site, page), :remote => true do
           %span= t('.toggle')
-        
+
     .icon{:class => page.is_published?? 'published' : 'draft'}
       - if !category_view && has_siblings
         .dragger
           %span &#8645;
-          
+
     .btn-group.btn-group-sm
       = link_to t('.add_child_page'), new_comfy_admin_cms_site_page_path(@site, :parent_id => page.id), :class => 'btn btn-default'
       = link_to t('.edit'), edit_comfy_admin_cms_site_page_path(@site, page), :class => 'btn btn-default'
       = link_to t('.delete'), comfy_admin_cms_site_page_path(@site, page), :method => :delete, :data => {:confirm => t('.are_you_sure')}, :class => 'btn btn-danger'
-      
+
     .item-content
       .item-title
         = link_to page.label, edit_comfy_admin_cms_site_page_path(@site, page), :class => 'item-label'
+        - if page.published?
+          %span.label.label-success.pull-right.published-label
+            %h6.published-status
+              ="Published #{friendly_date(page.updated_at)}"
+        - else
+          %span.label.label-warning.pull-right.published-label
+            - if page.has_published_revision?
+              %h6.published-status
+                ="Published revision: #{friendly_date(page.latest_published_revision.created_at)}"
+            - else
+              %h6.published-status
+                Not publicly visible
         = render :partial => 'comfy/admin/cms/categories/categories', :object => page
       .item-meta
-        = link_to page.url, page.url, :target => '_blank'
-        
+        = link_to page.full_path, page.full_path, :target => '_blank'
+
   - if !category_view && has_children && branch_open
     %ul.children.sortable
       = render :partial => 'index_branch', :collection => children


### PR DESCRIPTION
- add label in pages view to show published status
- highlight pages that are drafted
  ![screen shot 2016-08-29 at 4 56 34 pm](https://cloud.githubusercontent.com/assets/7543705/18071305/99029f24-6e09-11e6-9bab-612196672687.png)
- fixes this link to be relative, making it actually useful

![screen shot 2016-08-29 at 4 55 23 pm](https://cloud.githubusercontent.com/assets/7543705/18071280/6e43a350-6e09-11e6-95f0-b2c46278e59f.png)
