### PR TITLE
Add the ability to clone pages

### DIFF
--- a/app/controllers/comfy/admin/cms/pages_controller.rb
+++ b/app/controllers/comfy/admin/cms/pages_controller.rb
@@ -1,7 +1,7 @@
 class Comfy::Admin::Cms::PagesController < Comfy::Admin::Cms::BaseController
   before_action :check_for_layouts, :only => [:new, :edit]
   before_action :build_cms_page,    :only => [:new, :create]
-  before_action :load_cms_page,     :only => [:edit, :update, :destroy]
+  before_action :load_cms_page,     :only => [:edit, :update, :clone, :destroy]
   before_action :authorize
   before_action :preview_cms_page,  :only => [:create, :update]
   before_action :clear_cache, :only => [:create, :update, :destroy]
@@ -77,6 +77,12 @@ class Comfy::Admin::Cms::PagesController < Comfy::Admin::Cms::BaseController
     render :nothing => true
   end
 
+  def clone
+    deep_clone_cms_page
+    flash[:success] = I18n.t('comfy.admin.cms.pages.created')
+    redirect_to :action => :index
+  end
+
   def clear_cache(page = @page)
     page_and_ancestors = [page] + page.ancestors
     page_and_ancestors.each do |p|
@@ -150,6 +156,23 @@ protected
       response.headers['X-XSS-Protection'] = '0'
 
       render :inline => @page.render, :layout => layout, :content_type => 'text/html'
+    end
+  end
+
+  def deep_clone_cms_page
+    raise 'Page cannot be cloned' unless @page.can_be_cloned?
+    cloned_page = @page.dup
+    cloned_page.slug = "#{@page.slug}-copy-#{SecureRandom.hex 2}"
+    cloned_page.label = "#{@page.label} - Copy"
+    cloned_page.aasm_state = 'drafted'
+    cloned_page.save!
+    # changing the state to drafted above creates a revision, so blast it
+    cloned_page.revisions.destroy_all
+    # clone all child pages
+    @page.children.each do |child_page|
+      cloned_child = child_page.dup
+      cloned_child.parent = cloned_page
+      cloned_child.save!
     end
   end
 

--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -110,6 +110,18 @@ class Comfy::Cms::Page < ActiveRecord::Base
     end
   end
 
+  # Whether we allow a page to have child pages.
+  # Currently we only allow top level pages and sites to have children
+  def can_have_children?
+    self.ancestors.count <= 1
+  end
+
+  # Whether we allow a page to be cloned
+  # Currently we only allow top level pages to be cloned
+  def can_be_cloned?
+    self.ancestors.count == 1
+  end
+
 protected
 
   def assigns_label

--- a/app/views/comfy/admin/cms/pages/_index_branch.html.haml
+++ b/app/views/comfy/admin/cms/pages/_index_branch.html.haml
@@ -19,8 +19,11 @@
           %span &#8645;
 
     .btn-group.btn-group-sm
-      = link_to t('.add_child_page'), new_comfy_admin_cms_site_page_path(@site, :parent_id => page.id), :class => 'btn btn-default'
       = link_to t('.edit'), edit_comfy_admin_cms_site_page_path(@site, page), :class => 'btn btn-default'
+      - if page.can_have_children?
+        = link_to t('.add_child_page'), new_comfy_admin_cms_site_page_path(@site, :parent_id => page.id), :class => 'btn btn-default'
+      - if page.can_be_cloned?
+        = link_to t('.clone'), clone_comfy_admin_cms_site_page_path(@site, page), :method => :put, :data => {:confirm => t('.are_you_sure')}, :class => 'btn btn-default'
       = link_to t('.delete'), comfy_admin_cms_site_page_path(@site, page), :method => :delete, :data => {:confirm => t('.are_you_sure')}, :class => 'btn btn-danger'
 
     .item-content

--- a/app/views/layouts/comfy/admin/cms.html.haml
+++ b/app/views/layouts/comfy/admin/cms.html.haml
@@ -1,5 +1,6 @@
 !!!
 %html{:lang => I18n.locale}
   = render 'layouts/comfy/admin/cms/head'
+  = render 'layouts/comfy/admin/cms/flash'
   = render 'layouts/comfy/admin/cms/body'
   = render 'comfy/admin/cms/files/modal' if @site && !@site.new_record?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,7 @@ en:
             toggle: Toggle
             add_child_page: Add Child Page
             edit: Edit
+            clone: Clone
             delete: Delete
             are_you_sure: Are you sure?
           new:

--- a/lib/comfortable_mexican_sofa/routes/cms_admin.rb
+++ b/lib/comfortable_mexican_sofa/routes/cms_admin.rb
@@ -12,6 +12,7 @@ class ActionDispatch::Routing::Mapper
               get  :form_blocks,    :on => :member
               get  :toggle_branch,  :on => :member
               put :reorder,         :on => :collection
+              put :clone,           :on => :member
               resources :revisions, :only => [:index, :show, :revert] do
                 patch :revert, :on => :member
               end


### PR DESCRIPTION
Adds the ability to clone a page (with all of its sub pages / sections). The new cloned page is set as unpublished and given a semi-random URL to avoid conflicts as the url is expected to be changed later by the user

Fixes flash messages not showing